### PR TITLE
Add Terraform 1.4, 1.5 and 1.6 to the test mix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,9 @@ jobs:
           - "1.1.*"
           - "1.2.*"
           - "1.3.*"
+          - "1.4.*"
+          - "1.5.*"
+          - "1.6.*"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4


### PR DESCRIPTION
To ensure newer Terraform versions are supported, we want to test against 1.4, 1.5 and 1.6
